### PR TITLE
w1d4 remove random  'v' from imports

### DIFF
--- a/tutorials/W1D4_Paleoclimate/W1D4_Tutorial1.ipynb
+++ b/tutorials/W1D4_Paleoclimate/W1D4_Tutorial1.ipynb
@@ -86,9 +86,7 @@
     "import lipd\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
-    "import cartopy.io.shapereader as shapereader\n",
-    "\n",
-    "v"
+    "import cartopy.io.shapereader as shapereader"
    ]
   },
   {
@@ -651,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Mean this branch to fix this issue but @WesleyTheGeolien  already added the code in a different commit. During that commit there was a 'v' added to the imports by mistake and this removes it.